### PR TITLE
Added bash-ruby and cleaned up containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY:
+
+default: run
+
+DIR?=
+
+build:
+	docker-compose build --no-cache --pull --force-rm $(DIR)
+	docker tag terryhorner/$(DIR):latest terryhorner/$(DIR):latest
+
+publish: build
+	docker push terryhorner/$(DIR)
+
+run:
+	docker-compose -f docker-compose.yaml build --force-rm --pull $(DIR)
+	docker-compose -f docker-compose.yaml run --rm $(DIR)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # Dockerfiles
 Dockerfile dumping ground.
+
+## Running a bash container
+
+Pull the latest version from Docker Hub:
+
+```
+$ docker pull terryhorner/bash-ruby:latest
+latest: Pulling from terryhorner/bash-ruby
+Digest: sha256:ed7e2bf268b6d4d442772cb93877cb0a919a810bb33e122beb342722364c93ff
+Status: Downloaded newer image for terryhorner/bash-ruby:latest
+```
+
+Then run the container and hop into a bash terminal while mounting the current directory to `/local` inside the container:
+
+```
+$ docker run -v ${PWD}:/local -it terryhorner/bash-ruby:latest bin/bash
+bash-4.4#
+```
+
+Mounting the current directory into the container at `/local` gives you a quick and easy way to run code with minimal hassle.

--- a/bash-python/Dockerfile
+++ b/bash-python/Dockerfile
@@ -1,9 +1,4 @@
 FROM python:3.7-alpine
 LABEL maintainer "Terry Horner <terrhorn@teket.io>"
 
-COPY . .
-
 RUN apk add --no-cache bash
-RUN pip install --no-cache-dir -r requirements.txt
-
-CMD ["/bin/bash"]

--- a/bash-ruby/Dockerfile
+++ b/bash-ruby/Dockerfile
@@ -1,0 +1,9 @@
+FROM ruby:2.5.3-alpine3.7
+LABEL maintainer "Terry Horner <terrhorn@teket.io>"
+
+COPY . .
+
+RUN apk add --no-cache bash
+RUN bundle install; exit 0
+
+CMD ["/bin/bash"]

--- a/bash-ruby/Dockerfile
+++ b/bash-ruby/Dockerfile
@@ -1,9 +1,4 @@
 FROM ruby:2.5.3-alpine3.7
 LABEL maintainer "Terry Horner <terrhorn@teket.io>"
 
-COPY . .
-
 RUN apk add --no-cache bash
-RUN bundle install; exit 0
-
-CMD ["/bin/bash"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.3"
+
+services:
+  bash-python:
+    build: bash-python/.
+    image: terryhorner/bash-python:latest
+    command: ["/bin/bash"]
+    volumes:
+      - ./:/local
+
+  bash-ruby:
+    build: bash-ruby/.
+    image: terryhorner/bash-ruby:latest
+    command: ["/bin/bash"]
+    volumes:
+      - ./:/local


### PR DESCRIPTION
This is a hastily thrown together solution that is a bit more portable than the previous "copy the Dockerfile and build it in the local directory" hack I threw together previously.

Docker images are publicly available at [terryhorner/bash-ruby](https://hub.docker.com/r/terryhorner/bash-ruby/) and [terryhorner/bash-python](https://hub.docker.com/r/terryhorner/bash-python/).